### PR TITLE
Refactor of AnyOfCodeGenerator to ease future development

### DIFF
--- a/src/AnyOfCodeGenerator/AnyOfCodeGenerator.cs
+++ b/src/AnyOfCodeGenerator/AnyOfCodeGenerator.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using System.Text;
-using AnyOf.SourceGenerator;
+﻿using AnyOf.SourceGenerator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
 
 namespace AnyOfGenerator;
 
@@ -61,31 +61,32 @@ public class AnyOfCodeGenerator : ISourceGenerator
     {
         const string filename = "HashCodeCalculator.g.cs";
 
-        var sb = new StringBuilder();
-        sb.Append(AddHeader());
-        sb.AppendLine("using System.Collections.Generic;");
-        sb.AppendLine("using System.Linq;");
-        sb.AppendLine();
+        var sb = new StringBuilder(AddHeader());
 
-        sb.AppendLine("namespace AnyOfTypes");
-        sb.AppendLine("{");
-        sb.AppendLine("    // Code is based on https://github.com/Informatievlaanderen/hashcode-calculator");
-        var method = @"    internal static class HashCodeCalculator
-    {
-        public static int GetHashCode(IEnumerable<object> hashFieldValues)
-        {
-            const int offset = unchecked((int)2166136261);
-            const int prime = 16777619;
-    
-            static int HashCodeAggregator(int hashCode, object value) => value == null
-                ? (hashCode ^ 0) * prime
-                : (hashCode ^ value.GetHashCode()) * prime;
-    
-            return hashFieldValues.Aggregate(offset, HashCodeAggregator);
-        }
-    }";
-        sb.AppendLine(method);
-        sb.AppendLine("}");
+        sb.AppendLine(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            namespace AnyOfTypes
+            {
+                // Code is based on https://github.com/Informatievlaanderen/hashcode-calculator
+                internal static class HashCodeCalculator
+                {
+                    public static int GetHashCode(IEnumerable<object> hashFieldValues)
+                    {
+                        const int offset = unchecked((int)2166136261);
+                        const int prime = 16777619;
+            
+                        static int HashCodeAggregator(int hashCode, object value) => value == null
+                            ? (hashCode ^ 0) * prime
+                            : (hashCode ^ value.GetHashCode()) * prime;
+            
+                        return hashFieldValues.Aggregate(offset, HashCodeAggregator);
+                    }
+                }
+            }
+            """);
 
         string code = sb.ToString();
 
@@ -109,19 +110,19 @@ public class AnyOfCodeGenerator : ISourceGenerator
     {
         const string filename = "AnyOfTypes.g.cs";
         var typeNames = GetTypeNames(Max);
-        var typesAsString = string.Join(", ", typeNames);
 
-        var sb = new StringBuilder();
-        sb.Append(AddHeader());
+        var sb = new StringBuilder(AddHeader());
+        sb.Append(
+            $$"""
+            namespace AnyOfTypes
+            {
 
-        sb.AppendLine("namespace AnyOfTypes");
-        sb.AppendLine("{");
-
-        sb.AppendLine("    public enum AnyOfType");
-        sb.AppendLine("    {");
-        sb.AppendLine($"        Undefined = 0, {typesAsString}");
-        sb.AppendLine("    }");
-        sb.AppendLine("}");
+                public enum AnyOfType
+                {
+                    Undefined = 0, {{string.Join(", ", typeNames.Select((x, i) => $"{x} = {i + 1}"))}}
+                }
+            }
+            """);
 
         string code = sb.ToString();
 
@@ -152,31 +153,31 @@ public class AnyOfCodeGenerator : ISourceGenerator
         {
             sb.AppendLine("#nullable enable");
         }
-        sb.AppendLine("using System;");
-        sb.AppendLine("using System.Diagnostics;");
-        sb.AppendLine("using System.Collections.Generic;");
-        sb.AppendLine();
 
-        sb.AppendLine("namespace AnyOfTypes");
-        sb.AppendLine("{");
+        sb.AppendLine(
+            $$"""
+            using System;
+            using System.Diagnostics;
+            using System.Collections.Generic;
 
-        sb.AppendLine($"    public struct AnyOfBase");
-        sb.AppendLine("    {");
+            namespace AnyOfTypes
+            {
+                public struct AnyOfBase
+                {
+                    public virtual int NumberOfTypes { get; private set; }
+                    private virtual object{nullable} _currentValue;
+                    private virtual readonly Type _currentValueType;
+                    private virtual readonly AnyOfType _currentType;
 
-        sb.AppendLine(@"        public virtual int NumberOfTypes { get; private set; }");
-        sb.AppendLine($"        private virtual object{nullable} _currentValue;");
-        sb.AppendLine(@"        private virtual readonly Type _currentValueType;");
-        sb.AppendLine(@"        private virtual readonly AnyOfType _currentType;");
-        sb.AppendLine();
+            {{AddProperty(@"AnyOfType", "CurrentType", "_currentType")}}
 
-        AddProperty(sb, @"AnyOfType", "CurrentType", "_currentType");
+            {{AddProperty($"object{nullable}", "CurrentValue", "_currentValue")}}
 
-        AddProperty(sb, $"object{nullable}", "CurrentValue", "_currentValue");
+            {{AddProperty(@"Type", "CurrentValueType", "_currentValueType")}}
+                }
+            }
+            """);
 
-        AddProperty(sb, @"Type", "CurrentValueType", "_currentValueType");
-
-        sb.AppendLine("    }");
-        sb.AppendLine("}");
         if (options.SupportsNullable)
         {
             sb.AppendLine("#nullable disable");
@@ -210,137 +211,145 @@ public class AnyOfCodeGenerator : ISourceGenerator
         var nullable = options.SupportsNullable ? "?" : string.Empty;
         var @default = options.SupportsNullable ? "!" : string.Empty;
 
-        var sb = new StringBuilder();
-        sb.Append(AddHeader());
+        var sb = new StringBuilder(AddHeader());
 
         if (options.SupportsNullable)
         {
             sb.AppendLine("#nullable enable");
         }
-        sb.AppendLine("using System;");
-        sb.AppendLine("using System.Diagnostics;");
-        sb.AppendLine("using System.Collections.Generic;");
-        sb.AppendLine();
 
-        sb.AppendLine("namespace AnyOfTypes");
-        sb.AppendLine("{");
+        sb.AppendLine(
+            $$"""
+            using System;
+            using System.Diagnostics;
+            using System.Collections.Generic;
 
-        sb.AppendLine("    [DebuggerDisplay(\"{_thisType}, AnyOfType = {_currentType}; Type = {_currentValueType?.Name}; Value = '{ToString()}'\")]");
-        sb.AppendLine($"    public struct AnyOf<{genericTypesAsCommaSeparatedString}> : IEquatable<AnyOf<{genericTypesAsCommaSeparatedString}>>");
-        sb.AppendLine("    {");
+            namespace AnyOfTypes
+            {
+                [DebuggerDisplay("{_thisType}, AnyOfType = {_currentType}; Type = {_currentValueType?.Name}; Value = '{ToString()}'")]
+                public struct AnyOf<{{genericTypesAsCommaSeparatedString}}> : IEquatable<AnyOf<{{genericTypesAsCommaSeparatedString}}>>
+                {
+                    private readonly string _thisType => $"{{thisType}}";
+                    private readonly int _numberOfTypes;
+                    private readonly object{{nullable}} _currentValue;
+                    private readonly Type _currentValueType;
+                    private readonly AnyOfType _currentType;
 
-        sb.AppendLine($"        private readonly string _thisType => $\"{thisType}\";");
-        sb.AppendLine(@"        private readonly int _numberOfTypes;");
-        sb.AppendLine($"        private readonly object{nullable} _currentValue;");
-        sb.AppendLine(@"        private readonly Type _currentValueType;");
-        sb.AppendLine(@"        private readonly AnyOfType _currentType;");
-        sb.AppendLine();
+            {{string.Join(
+                Environment.NewLine,
+                typeNames.Select(t => $"        private readonly T{t} _{t.ToLowerInvariant()};"))}}
 
-        Array.ForEach(typeNames, t => sb.AppendLine($"        private readonly T{t} _{t.ToLowerInvariant()};"));
-        sb.AppendLine();
+                    public readonly AnyOfType[] AnyOfTypes => new[] { {{string.Join(", ", typeNames.Select(t => $"AnyOfType.{t}"))}} };
+                    public readonly Type[] Types => new[] { {{typesAsCommaSeparatedString}} };
 
-        sb.AppendLine($"        public readonly AnyOfType[] AnyOfTypes => new[] {{ {string.Join(", ", typeNames.Select(t => $"AnyOfType.{t}"))} }};");
+                    public bool IsUndefined => _currentType == AnyOfType.Undefined;
 
-        sb.AppendLine($"        public readonly Type[] Types => new[] {{ {typesAsCommaSeparatedString} }};");
+            {{string.Join(
+                Environment.NewLine,
+                typeNames.Select(t => $"        public bool Is{t} => _currentType == AnyOfType.{t};"))}}
 
-        sb.AppendLine(@"        public bool IsUndefined => _currentType == AnyOfType.Undefined;");
-        Array.ForEach(typeNames, t => sb.AppendLine($"        public bool Is{t} => _currentType == AnyOfType.{t};"));
-        sb.AppendLine();
+            """);
 
-        Array.ForEach(typeNames, t =>
+
+        Array.ForEach(typeNames, typeName =>
         {
-            sb.AppendLine($"        public static implicit operator AnyOf<{genericTypesAsCommaSeparatedString}>(T{t} value) => new AnyOf<{genericTypesAsCommaSeparatedString}>(value);");
-            sb.AppendLine();
+            sb.AppendLine(
+                $$"""
+                        public static implicit operator AnyOf<{{genericTypesAsCommaSeparatedString}}>(T{{typeName}} value) => new AnyOf<{{genericTypesAsCommaSeparatedString}}>(value);
 
-            sb.AppendLine($"        public static implicit operator T{t}(AnyOf<{genericTypesAsCommaSeparatedString}> @this) => @this.{t};");
-            sb.AppendLine();
+                        public static implicit operator T{{typeName}}(AnyOf<{{genericTypesAsCommaSeparatedString}}> @this) => @this.{{typeName}};
 
-            sb.AppendLine($"        public AnyOf(T{t} value)");
-            sb.AppendLine(@"        {");
-            sb.AppendLine($"            _numberOfTypes = {numberOfTypes};");
-            sb.AppendLine($"            _currentType = AnyOfType.{t};");
-            sb.AppendLine($"            _currentValue = value;");
-            sb.AppendLine($"            _currentValueType = typeof(T{t});");
-            sb.AppendLine($"            _{t.ToLowerInvariant()} = value;");
-            Array.ForEach(typeNames.Except(new[] { t }).ToArray(), dt => sb.AppendLine($"            _{dt.ToLowerInvariant()} = default{@default};"));
-            sb.AppendLine(@"        }");
-            sb.AppendLine();
+                        public AnyOf(T{{typeName}} value)
+                        {
+                            _numberOfTypes = {{numberOfTypes}};
+                            _currentType = AnyOfType.{{typeName}};
+                            _currentValue = value;
+                            _currentValueType = typeof(T{{typeName}});
+                {{string.Join(
+                    Environment.NewLine,
+                    typeNames.Select(t => t == typeName
+                        ? $"            _{t.ToLowerInvariant()} = value;"
+                        : $"            _{t.ToLowerInvariant()} = default{@default};"))}}
+                        }
 
-            sb.AppendLine($"        public T{t} {t}");
-            sb.AppendLine(@"        {");
-            sb.AppendLine(@"            get");
-            sb.AppendLine(@"            {");
-            sb.AppendLine($"               Validate(AnyOfType.{t});");
-            sb.AppendLine($"               return _{t.ToLowerInvariant()};");
-            sb.AppendLine(@"            }");
-            sb.AppendLine(@"        }");
-            sb.AppendLine();
+                        public T{{typeName}} {{typeName}}
+                        {
+                            get
+                            {
+                                Validate(AnyOfType.{{typeName}});
+                                return _{{typeName.ToLowerInvariant()}};
+                            }
+                        }
+
+                """);
         });
 
-        sb.AppendLine("        private void Validate(AnyOfType desiredType)");
-        sb.AppendLine("        {");
-        sb.AppendLine("            if (desiredType != _currentType)");
-        sb.AppendLine("            {");
-        sb.AppendLine("                throw new InvalidOperationException($\"Attempting to get {desiredType} when {_currentType} is set\");");
-        sb.AppendLine("            }");
-        sb.AppendLine("        }");
-        sb.AppendLine();
+        sb.AppendLine(
+            $$"""
+                    private void Validate(AnyOfType desiredType)
+                    {
+                        if (desiredType != _currentType)
+                        {
+                            throw new InvalidOperationException($"Attempting to get {desiredType} when {_currentType} is set");
+                        }
+                    }
 
-        AddProperty(sb, "AnyOfType", "CurrentType", "_currentType");
+            {{AddProperty("AnyOfType", "CurrentType", "_currentType")}}
 
-        AddProperty(sb, $"object{nullable}", "CurrentValue", "_currentValue");
+            {{AddProperty($"object{nullable}", "CurrentValue", "_currentValue")}}
 
-        AddProperty(sb, "Type", "CurrentValueType", "_currentValueType");
+            {{AddProperty("Type", "CurrentValueType", "_currentValueType")}}
 
-        sb.AppendLine("        public override int GetHashCode()");
-        sb.AppendLine("        {");
-        sb.AppendLine("            var fields = new object[]");
-        sb.AppendLine("            {");
-        sb.AppendLine("                _numberOfTypes,");
-        sb.AppendLine("                _currentValue,");
-        sb.AppendLine("                _currentType,");
-        Array.ForEach(typeNames, t => sb.AppendLine($"                _{t.ToLowerInvariant()},"));
-        Array.ForEach(typeNames, t => sb.AppendLine($"                typeof(T{t}),"));
-        sb.AppendLine("            };");
-        sb.AppendLine("            return HashCodeCalculator.GetHashCode(fields);");
-        sb.AppendLine("        }");
-        sb.AppendLine();
+                    public override int GetHashCode()
+                    {
+                        var fields = new object[]
+                        {
+                            _numberOfTypes,
+                            _currentValue,
+                            _currentType,
+            {{string.Join(
+                Environment.NewLine,
+                typeNames.Select(t => $"                _{t.ToLowerInvariant()},"))}}
+            {{string.Join(
+                Environment.NewLine,
+                typeNames.Select(t => $"                typeof(T{t}),"))}}
+                        };
+                        return HashCodeCalculator.GetHashCode(fields);
+                    }
 
-        sb.AppendLine($"        public bool Equals(AnyOf<{genericTypesAsCommaSeparatedString}> other)");
-        sb.AppendLine(@"        {");
-        sb.AppendLine(@"            return _currentType == other._currentType &&");
-        sb.AppendLine(@"                   _numberOfTypes == other._numberOfTypes &&");
-        sb.AppendLine($"                   EqualityComparer<object{nullable}>.Default.Equals(_currentValue, other._currentValue) &&");
-        Array.ForEach(typeNames, t => sb.AppendLine($"                    EqualityComparer<T{t}>.Default.Equals(_{t.ToLowerInvariant()}, other._{t.ToLowerInvariant()}){(t == typeNames.Last() ? ";" : " &&")}"));
-        sb.AppendLine(@"        }");
-        sb.AppendLine();
+                    public bool Equals(AnyOf<{{genericTypesAsCommaSeparatedString}}> other)
+                    {
+                        return _currentType == other._currentType &&
+                            _numberOfTypes == other._numberOfTypes &&
+                            EqualityComparer<object{{nullable}}>.Default.Equals(_currentValue, other._currentValue) &&
+            {{string.Join(
+                Environment.NewLine,
+                typeNames.Select(t => $"                EqualityComparer<T{t}>.Default.Equals(_{t.ToLowerInvariant()}, other._{t.ToLowerInvariant()}){(t == typeNames.Last() ? ";" : " &&")}"))}}
+                    }
 
-        sb.AppendLine($"        public static bool operator ==(AnyOf<{genericTypesAsCommaSeparatedString}> obj1, AnyOf<{genericTypesAsCommaSeparatedString}> obj2)");
-        sb.AppendLine("        {");
-        sb.AppendLine($"            return EqualityComparer<AnyOf<{genericTypesAsCommaSeparatedString}>>.Default.Equals(obj1, obj2);");
-        sb.AppendLine("        }");
-        sb.AppendLine();
+                    public static bool operator ==(AnyOf<{{genericTypesAsCommaSeparatedString}}> obj1, AnyOf<{{genericTypesAsCommaSeparatedString}}> obj2)
+                    {
+                        return EqualityComparer<AnyOf<{{genericTypesAsCommaSeparatedString}}>>.Default.Equals(obj1, obj2);
+                    }
 
-        sb.AppendLine($"        public static bool operator !=(AnyOf<{genericTypesAsCommaSeparatedString}> obj1, AnyOf<{genericTypesAsCommaSeparatedString}> obj2)");
-        sb.AppendLine(@"        {");
-        sb.AppendLine(@"            return !(obj1 == obj2);");
-        sb.AppendLine(@"        }");
-        sb.AppendLine();
+                    public static bool operator !=(AnyOf<{{genericTypesAsCommaSeparatedString}}> obj1, AnyOf<{{genericTypesAsCommaSeparatedString}}> obj2)
+                    {
+                        return !(obj1 == obj2);
+                    }
 
-        sb.AppendLine($"        public override bool Equals(object{nullable} obj)");
-        sb.AppendLine("        {");
-        sb.AppendLine($"            return obj is AnyOf<{genericTypesAsCommaSeparatedString}> o && Equals(o);");
-        sb.AppendLine("        }");
-        sb.AppendLine();
+                    public override bool Equals(object{{nullable}} obj)
+                    {
+                        return obj is AnyOf<{{genericTypesAsCommaSeparatedString}}> o && Equals(o);
+                    }
 
-        sb.AppendLine($"        public override string{nullable} ToString()");
-        sb.AppendLine("        {");
-        sb.AppendLine("            return IsUndefined ? null : $\"{_currentValue}\";");
-        sb.AppendLine("        }");
+                    public override string{{nullable}} ToString()
+                    {
+                        return IsUndefined ? null : $"{_currentValue}";
+                    }
+                }
+            }
+            """);
 
-        sb.AppendLine("    }");
-
-        sb.AppendLine("}");
         if (options.SupportsNullable)
         {
             sb.AppendLine("#nullable disable");
@@ -364,39 +373,27 @@ public class AnyOfCodeGenerator : ISourceGenerator
         }
     }
 
-    private static void AddProperty(StringBuilder src, string type, string name, string privateField)
-    {
-        //src.AppendLine($"        public {type} {name}");
-        //src.AppendLine("        {");
-        //src.AppendLine("            get");
-        //src.AppendLine("            {");
-        //src.AppendLine($"               return {privateField};");
-        //src.AppendLine("            }");
-        //src.AppendLine("        }");
-        //src.AppendLine();
+    private static string AddProperty(string type, string name, string privateField) =>
+        $$"""
+                public {{type}} {{name}}
+                {
+                    get
+                    {
+                        return {{privateField}};
+                    }
+                }
+        """;
 
-        src.AppendLine($"        public {type} {name}");
-        src.AppendLine("        {");
-        src.AppendLine("            get");
-        src.AppendLine("            {");
-        src.AppendLine($"               return {privateField};");
-        src.AppendLine("            }");
-        src.AppendLine("        }");
-        src.AppendLine();
-    }
+    private static string AddHeader() =>
+        """
+        //------------------------------------------------------------------------------
+        // <auto-generated>
+        //     This code was generated by https://github.com/StefH/AnyOf.
+        //
+        //     Changes to this file may cause incorrect behavior and will be lost if
+        //     the code is regenerated.
+        // </auto-generated>
+        //------------------------------------------------------------------------------
 
-    private static StringBuilder AddHeader()
-    {
-        var sb = new StringBuilder();
-        sb.AppendLine("//------------------------------------------------------------------------------");
-        sb.AppendLine("// <auto-generated>");
-        sb.AppendLine("//     This code was generated by https://github.com/StefH/AnyOf.");
-        sb.AppendLine("//");
-        sb.AppendLine("//     Changes to this file may cause incorrect behavior and will be lost if");
-        sb.AppendLine("//     the code is regenerated.");
-        sb.AppendLine("// </auto-generated>");
-        sb.AppendLine("//------------------------------------------------------------------------------");
-        sb.AppendLine();
-        return sb;
-    }
+        """;
 }


### PR DESCRIPTION
I would like to develop a feature that I think is missing from this library and could be very useful when working in ASP.NET and service->controller communication.

First I thought I'll refactor the code generator so any future changes are easier to implement. I changed the generator from appending the files line by line to using as large as possible interpolated string literals. They are converted into a string builder before compilation so the logic remains exactly the same, but it makes the code cleaner and easier to maintain.

Newly generated classes are almost identical to old ones.

There are two changes.
- AnyOfTypes.g.cs - I added values to the enum:

(old)
```
public enum AnyOfType
{
    Undefined = 0, First, Second, Third, Fourth, Fifth, Sixth, Seventh, Eighth, Ninth, Tenth
}
```
(new)
```
public enum AnyOfType
{
    Undefined = 0, First = 1, Second = 2, Third = 3, Fourth = 4, Fifth = 5, Sixth = 6, Seventh = 7, Eighth = 8, Ninth = 9, Tenth = 10
}
```

- AnyOf_??.g.cs - the order of fields in the constructor now is always sequential:

(old)
```
public AnyOf(TSecond value)
{
    _numberOfTypes = 3;
    _currentType = AnyOfType.Second;
    _currentValue = value;
    _currentValueType = typeof(TSecond);
    _second = value;
    _first = default!;
    _third = default!;
}
```
(new)
```
public AnyOf(TSecond value)
{
    _numberOfTypes = 3;
    _currentType = AnyOfType.Second;
    _currentValue = value;
    _currentValueType = typeof(TSecond);
    _first = default!;
    _second = value;
    _third = default!;
}
```